### PR TITLE
Add information about GSI binary fix files to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,14 @@ These include (but are not limited to):
 - hybrid covariance weights
 - control and state vector descriptions
 
+Binary files used by the [GSI](https://github.com/NOAA-EMC/GSI) are available from two sources:
+- staged in directory `GSI_BINARY_SOURCE_DIR` on WCOSS2 and select NOAA RHDPCS machines.
+  Variable `GSI_BINARY_SOURCE_DIR` is defined in [GSI/modulefiles](https://github.com/NOAA-EMC/GSI/modulefiles) `gsi_$machine.lua`
+  for some, but not all, machines.
+- downloadable as a tarball from https://ftp.emc.ncep.noaa.gov/static_files/public/gsi.
+  See [GSI-fix/CmakeLists.txt]/(https://github.com/NOAA-EMC/GSI-fix/CMakeLists.txt) for the name of the GSI binary tarball.
+
+
 ## What files are what
 The top level directory structure groups the files as follow:
 

--- a/README.md
+++ b/README.md
@@ -8,12 +8,12 @@ These include (but are not limited to):
 - hybrid covariance weights
 - control and state vector descriptions
 
-Binary files used by the [GSI](https://github.com/NOAA-EMC/GSI) are available from two sources:
+Binary files used by the [GSI](https://github.com/NOAA-EMC/GSI) are **NOT** in [GSI-fix](https://github.com/NOAA-EMC/GSI-fix).
+Instead, GSI binary fix files are available from two sources:
 - staged in directory `GSI_BINARY_SOURCE_DIR` on WCOSS2 and select NOAA RHDPCS machines.
-  Variable `GSI_BINARY_SOURCE_DIR` is defined in [GSI/modulefiles](https://github.com/NOAA-EMC/GSI/modulefiles) `gsi_$machine.lua`
+  Variable `GSI_BINARY_SOURCE_DIR` is defined in [GSI](https://github.com/NOAA-EMC/GSI) `modulefiles/gsi_$machine.lua`
   for some, but not all, machines.
 - downloadable as a tarball from https://ftp.emc.ncep.noaa.gov/static_files/public/gsi.
-  See [GSI-fix/CmakeLists.txt]/(https://github.com/NOAA-EMC/GSI-fix/CMakeLists.txt) for the name of the GSI binary tarball.
 
 
 ## What files are what


### PR DESCRIPTION
GSI ASCII fix files are maintained in [NOAA-EMC/GSI-fix](https://github.com/NOAA-EMC/GSI-fix).   GSI binary fix files are maintained, at present, in two locations:  staged on disk or downloadable from the EMC FTP site.

The `README.md` of `feature/readme` adds a section documenting where GSI binary fix files currently reside.  This information is added so users have a complete picture of GSI-fix files.     

