### PR TITLE
Add Rcov_crisn21

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -156,3 +156,4 @@ nam_nmm_berror.f77.gcv
 Rcov_iasialand
 Rcov_crisnpp
 Rcov_iasicsea
+Rcov_crisn21

--- a/gsi_binary_files.cmake
+++ b/gsi_binary_files.cmake
@@ -120,4 +120,5 @@ list(APPEND gsi_binaries
   Rcov_iasialand
   Rcov_crisnpp
   Rcov_iasicsea
+  Rcov_crisn21
 )


### PR DESCRIPTION
This PR updates two files
 - `gsi_binary_files.cmake` - add `Rcov_crisn21` to the list of GSI binary files to copy to local `fix/`
 - `.gitignore` - add `Rcov_crisn21` so that it is not accidently committed to GSI-fix

The operational GFS assimiliates cris-fsr_n21.  The changes in this PR bring GSI-fix `develop` into alignment with operations.

Fixes #16