### PR TITLE
Add ni and nr to global_anavinfo.l127 for Thompson-MP

### DIFF
--- a/global_anavinfo.l127.txt
+++ b/global_anavinfo.l127.txt
@@ -25,6 +25,8 @@ met_guess::
   qr      127      12         rain                 qr
   qs      127      12         snow                 qs
   qg      127      12         graupel              qg
+  ni      127       1         cloud_ice conc       ni
+  nr      127       1         rain conc            nr
 ! cf      127       1         cloud amount         cf
 ::
 


### PR DESCRIPTION
The new Thompson-MP in GSI introduces two extra hydrometeor variables compared to the previous GFDL MP. Update the `fix/global_anavinfo.l127.txt` to include these two variables, `ni` and `nr`.
Resolves [#21 ](https://github.com/NOAA-EMC/GSI-fix/issues/21)